### PR TITLE
feat: ssl proxy가 적용된 https api server 연결 변경 (#17)

### DIFF
--- a/src/controllers/detail.controller.js
+++ b/src/controllers/detail.controller.js
@@ -7,7 +7,7 @@ export default () => {
     divElement.innerHTML = views;
 
     const postId = localStorage.getItem('postId');
-    const API_URL = 'http://43.201.103.199/post/' + postId;
+    const API_URL = 'https://27.96.131.49/post/' + postId;
 
     Axios.get(API_URL, {
         headers: {'Content-Security-Policy': 'upgrade-insecure-requests'},

--- a/src/controllers/home.controller.js
+++ b/src/controllers/home.controller.js
@@ -6,7 +6,7 @@ export default () => {
     divElement.classList = "home-section";
     divElement.innerHTML = views;
 
-    const API_URL = 'http://43.201.103.199/posts';
+    const API_URL = 'https://27.96.131.49/posts';
 
     Axios.get(API_URL, {
         headers: {'Content-Security-Policy': 'upgrade-insecure-requests'},


### PR DESCRIPTION
## 작업 내용

- Nginx 에 open ssl 적용해 기존 http api server 를 중간 ssl 프록시 서버로 넘겨줌으로서 배포 이슈 해결

## 공유사항

Resolves #17 
